### PR TITLE
LDS-5531

### DIFF
--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -1,11 +1,85 @@
 import time
 
+from . import constant as constant
 from . import manage_ecs as ecs_manager
 
 
+SHUTDOWN_CHECK_INTERVAL = 15  # seconds between polls
+SHUTDOWN_TIMEOUT = 900  # 15 minutes max, same as Lambda timeout budget
+
+
+def _wait_for_active_jobs_to_complete(environment):
+    """Wait for all smuggler jobs to complete before shutting down, max 10 minutes."""
+    start_time = time.time()
+    while True:
+        metrics = environment.get_active_and_pending_smuggler_jobs()
+        active_jobs = metrics.get('active_jobs', 0)
+
+        if active_jobs == 0:
+            print("No active smuggler jobs, safe to proceed with shutdown")
+            return
+
+        elapsed = int(time.time() - start_time)
+        if elapsed > 600:
+            raise Exception("Smuggler jobs still active after 600s. Active: {}. Aborting deployment".format(active_jobs))
+
+        print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
+        time.sleep(SHUTDOWN_CHECK_INTERVAL)
+
+
+def ensure_environment_is_shut_down(environment):
+    """Ensure all services in the environment have 0 running tasks before proceeding.
+    This prevents old version tasks from coexisting with new ones after image tags are updated."""
+    _wait_for_active_jobs_to_complete(environment)
+
+    print("Sending shutdown to all {} services in {} environment".format(
+        len(environment.ecs_services), environment.color))
+    environment.shutdown_services()
+
+    start_time = time.time()
+    while (time.time() - start_time) < SHUTDOWN_TIMEOUT:
+        running_task_count = 0
+        services_with_tasks = []
+        for svc in environment.ecs_services:
+            tasks = svc.get_running_task_arns()
+            if tasks:
+                running_task_count += len(tasks)
+                services_with_tasks.append('{} ({})'.format(svc.service_arn, len(tasks)))
+
+        if running_task_count == 0:
+            elapsed = int(time.time() - start_time)
+            print("Pre-prod environment fully shut down in {}s, 0 tasks running".format(elapsed))
+            return
+
+        elapsed = int(time.time() - start_time)
+        print("Waiting for pre-prod shutdown: {} task(s) still running ({}s / {}s) - services: {}".format(
+            running_task_count, elapsed, SHUTDOWN_TIMEOUT, ', '.join(services_with_tasks)))
+        time.sleep(SHUTDOWN_CHECK_INTERVAL)
+
+    raise Exception("Pre-prod environment still has running tasks after {}s, aborting deployment".format(SHUTDOWN_TIMEOUT))
+
+
+def _build_service_arn_to_digest(environment, repo_name_to_digest):
+    """Build a mapping of service ARN to expected image digest using the repo→service mapping."""
+    repo_service_map = ecs_manager.get_map_of_repo_name_service(environment.color, environment.cluster_name)
+    service_arn_to_digest = {}
+    for repo_name, digest in repo_name_to_digest.items():
+        if repo_name in repo_service_map:
+            service_arn_to_digest[repo_service_map[repo_name].service_arn] = digest
+    return service_arn_to_digest
+
+
 # Démarre tous les services d'un environement et attend qu'il soit entièrement up
-def start_environment_and_wait_for_health(environment):
+def start_environment_and_wait_for_health(environment, repo_name_to_digest=None):
+    if repo_name_to_digest:
+        service_arn_to_digest = _build_service_arn_to_digest(environment, repo_name_to_digest)
+        print("Digest verification enabled for {} services".format(len(service_arn_to_digest)))
+        environment.set_expected_image_digests(service_arn_to_digest)
+    else:
+        print("Digest verification disabled (no digest mapping provided)")
+    print("Starting all {} services in {} environment".format(len(environment.ecs_services), environment.color))
     environment.start_up_services()
+    print("Waiting for all services to be healthy with correct image digest...")
     environment.wait_for_services_health()
 
 
@@ -19,24 +93,42 @@ def do_balancing(deployment_manager, from_environment, to_environment):
     )
 
 
-def deploy_services_of_repositories_name(environment, repositories_name):
-    print("Deploy services for repositories {}".format(repositories_name))
-
-    services_to_start = []
+def deploy_services_of_repositories_name(environment, repositories_name, repo_name_to_digest=None):
+    print("Deploy services for repositories: {}".format(repositories_name))
 
     repo_name_service_map = ecs_manager.get_map_of_repo_name_service(environment.color, environment.cluster_name)
 
-    # récupère les services à démarrer issus des repositories donnés
+    # Set expected digests on the environment's own services (not the throwaway instances from the map)
+    if repo_name_to_digest:
+        service_arn_to_digest = {}
+        for repo_name, digest in repo_name_to_digest.items():
+            if repo_name in repo_name_service_map:
+                service_arn_to_digest[repo_name_service_map[repo_name].service_arn] = digest
+        print("Digest verification enabled for {} services".format(len(service_arn_to_digest)))
+        environment.set_expected_image_digests(service_arn_to_digest)
+
+    # Collect environment services that match the repositories to deploy
+    services_to_start = []
     for repo_name in repositories_name:
         if repo_name in repo_name_service_map:
-            service = repo_name_service_map[repo_name]
-            services_to_start.append(service)
+            target_arn = repo_name_service_map[repo_name].service_arn
+            # Find the matching service in the environment's own list
+            for svc in environment.ecs_services:
+                if svc.service_arn == target_arn:
+                    services_to_start.append(svc)
+                    break
+
+    print("Matched {} services to redeploy out of {} repositories".format(
+        len(services_to_start), len(repositories_name)))
 
     if services_to_start:
         for service in services_to_start:
             print("Start service {}".format(service.resource_id))
             service.start()
 
-        # Wait for all service receive startup
+        # Wait only for the deployed services to be healthy (not all services in the environment)
         time.sleep(10)
-        environment.all_services_have_at_least_one_healthy_instance()
+        print("Waiting for {} redeployed services to be healthy with correct image digest...".format(len(services_to_start)))
+        environment.wait_for_services_health(services=services_to_start)
+    else:
+        print("No matching services found to redeploy")

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -136,6 +136,10 @@ class DeploymentManager:
         for r in self.repositories:
             r.add_tag(tag)
 
+    def get_expected_image_digests_by_repo(self):
+        """Returns a dict mapping repository name to expected imageDigest."""
+        return {r.name: r.image['imageDigest'] for r in self.repositories if r.image}
+
     def set_color_to_list_repositories_name(self, repositories_name):
         print('Add color {} to mismatched repositories: {}'.format(self.prod_color, repositories_name))
 
@@ -188,6 +192,16 @@ class Environment:
         self.ecs_services = ecs_services
         self.target_group_arn = target_group_arn
 
+    def set_expected_image_digests(self, service_arn_to_digest):
+        """Assign the expected image digest to each service.
+        Args:
+            service_arn_to_digest: dict mapping service ARN to expected imageDigest
+        """
+        for svc in self.ecs_services:
+            if svc.service_arn in service_arn_to_digest:
+                svc.expected_image_digest = service_arn_to_digest[svc.service_arn]
+                print('Set expected image digest for {}: {}'.format(svc.service_arn, svc.expected_image_digest))
+
     # Démarre tous les services
     def start_up_services(self, desired_count=None):
         for s in self.ecs_services:
@@ -212,20 +226,21 @@ class Environment:
     def all_services_have_at_least_one_healthy_instance(self):
         return all(s.has_at_least_one_healthy_instance() for s in self.ecs_services)
 
-    # Attend que tous les services soit healthy
-    def wait_for_services_health(self):
+    # Attend que tous les services (ou un sous-ensemble) soient healthy
+    def wait_for_services_health(self, services=None):
+        target_services = services if services is not None else self.ecs_services
         retry = 1
         print("Waiting {} seconds before first try".format(constant.HEALTHCHECK_SLEEPING_TIME))
         time.sleep(constant.HEALTHCHECK_SLEEPING_TIME)
-        while not self.all_services_have_at_least_one_healthy_instance() and constant.HEALTHCHECK_RETRY_LIMIT >= retry:
+        while not all(s.has_at_least_one_healthy_instance() for s in target_services) and constant.HEALTHCHECK_RETRY_LIMIT >= retry:
             print("Retry number {} all services hasnt healthy sleeping {} seconds before retry"
                   .format(retry, constant.HEALTHCHECK_SLEEPING_TIME))
             retry = retry + 1
             time.sleep(constant.HEALTHCHECK_SLEEPING_TIME)
         if constant.HEALTHCHECK_RETRY_LIMIT < retry:
             print("Tried {} but retry limit has been reach before all services been healthy".format(retry))
-            # Raise exception
-            unhealthy_sve = ",".join(list(map(lambda a: a.service_arn, self.get_unhealthy_services())))
+            unhealthy = [s for s in target_services if not s.has_at_least_one_healthy_instance()]
+            unhealthy_sve = ",".join(list(map(lambda a: a.service_arn, unhealthy)))
             raise Exception("Unable to deploy, services still unhealthy. Unhealthy Services : {}".format(unhealthy_sve))
         else:
             print("Tried {} and all service are now healthy".format(retry))
@@ -246,17 +261,19 @@ class EcsService:
     application_autoscaling_client = None
     max_capacity = None
     resource_id = None
+    expected_image_digest = None
 
     def __init__(self, ecs_client, application_autoscaling_client, cluster_name, service_arn, max_capacity,
-                 resource_id):
+                 resource_id, expected_image_digest=None):
         self.ecs_client = ecs_client
         self.cluster_name = cluster_name
         self.service_arn = service_arn
         self.application_autoscaling_client = application_autoscaling_client
         self.max_capacity = max_capacity
         self.resource_id = resource_id
+        self.expected_image_digest = expected_image_digest
 
-    def __get_task(self):
+    def get_running_task_arns(self):
         tasks = self.ecs_client.list_tasks(
             cluster=self.cluster_name,
             serviceName=self.service_arn,
@@ -317,15 +334,26 @@ class EcsService:
         return self.__check_health_with_threshold(constant.DEFAULT_DESIRED_COUNT)
 
     def __check_health_with_threshold(self, min_healthy_count):
-        tasks = self.__get_task()
+        tasks = self.get_running_task_arns()
         if not tasks:
             return False
         detailed_task = self.ecs_client.describe_tasks(
             cluster=self.cluster_name,
             tasks=tasks
         )
-        nb_healthy_task = len(list(filter(lambda x: x['healthStatus'] == 'HEALTHY', detailed_task['tasks'])))
+        running_tasks = [t for t in detailed_task['tasks'] if t['lastStatus'] == 'RUNNING']
+        nb_healthy_task = len([t for t in running_tasks if t['healthStatus'] == 'HEALTHY'])
         is_healthy = nb_healthy_task >= min_healthy_count
+
+        # If we have an expected image digest, verify ALL running tasks use the new image.
+        # This prevents old version tasks from coexisting with new ones during rolling updates.
+        if is_healthy and self.expected_image_digest:
+            old_tasks = self.__get_tasks_with_wrong_digest(running_tasks)
+            if old_tasks:
+                print('{} has {} healthy task(s) but {} task(s) still running with old image digest, waiting for rollout to complete'
+                      .format(self.service_arn, nb_healthy_task, len(old_tasks)))
+                return False
+
         if is_healthy:
             print('{} has reached the health threshold with {} healthy task(s) (required: {})'
                   .format(self.service_arn, nb_healthy_task, min_healthy_count))
@@ -333,6 +361,17 @@ class EcsService:
             print('{} has not reached the health threshold: {} healthy task(s) found, {} required'
                   .format(self.service_arn, nb_healthy_task, min_healthy_count))
         return is_healthy
+
+    def __get_tasks_with_wrong_digest(self, running_tasks):
+        """Returns tasks whose container image digest does not match the expected digest."""
+        old_tasks = []
+        for task in running_tasks:
+            for container in task.get('containers', []):
+                image_digest = container.get('imageDigest', '')
+                if image_digest and image_digest != self.expected_image_digest:
+                    old_tasks.append(task['taskArn'])
+                    break
+        return old_tasks
 
     def __str__(self):
         return self.service_arn


### PR DESCRIPTION
  Prevent old/new version coexistence during ECS rolling updates

  Add image digest verification to health checks: services are only
  considered healthy when ALL running tasks use the expected image digest,
  preventing old versions from coexisting with new ones and applying
  incompatible DB evolutions.

  - Add expected_image_digest field to EcsService
  - Verify container imageDigest in health check loop
  - Add ensure_environment_is_shut_down to guarantee 0 tasks before deploy
  - Add wait_for_services_health(services=) to target specific services