### PR TITLE
Bugfix/lds 5531 probleme deploiement lambda ave

### DIFF
--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -12,8 +12,8 @@ def _wait_for_active_jobs_to_complete(environment):
     """Wait for all smuggler jobs to complete before shutting down, max 10 minutes."""
     # start_time = time.time()
     # while True:
-    #     metrics = environment.get_active_and_pending_smuggler_jobs()
-    #     active_jobs = metrics.get('active_jobs', 0)
+    metrics = environment.get_active_and_pending_smuggler_jobs()
+    active_jobs = metrics.get('active_jobs', 0)
     #
     #     if active_jobs == 0:
     #         print("No active smuggler jobs, safe to proceed with shutdown")
@@ -67,7 +67,7 @@ def ensure_environment_is_shut_down(environment):
 
     raise Exception(
         "\n"
-        "/!\\ /!\\ /!\\ ECHEC DU SHUTDOWN /!\\ /!\\ /!\\\n"
+        "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
         "\n"
         "Le pre-prod a encore {} task(s) running apres {} secondes d'attente.\n"
         "Services concernes : {}\n"

--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -10,30 +10,30 @@ SHUTDOWN_TIMEOUT = 900  # 15 minutes max, same as Lambda timeout budget
 
 def _wait_for_active_jobs_to_complete(environment):
     """Wait for all smuggler jobs to complete before shutting down, max 10 minutes."""
-    start_time = time.time()
-    while True:
-        metrics = environment.get_active_and_pending_smuggler_jobs()
-        active_jobs = metrics.get('active_jobs', 0)
+    # start_time = time.time()
+    # while True:
+    #     metrics = environment.get_active_and_pending_smuggler_jobs()
+    #     active_jobs = metrics.get('active_jobs', 0)
+    #
+    #     if active_jobs == 0:
+    #         print("No active smuggler jobs, safe to proceed with shutdown")
+    #         return
+    #
+    #     elapsed = int(time.time() - start_time)
+    #     if elapsed > 600:
+    raise Exception(
+        "\n"
+        "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
+        "\n"
+        "{} job(s) smuggler toujours actif(s) apres 10 minutes d'attente.\n"
+        "\n"
+        "=> RELANCEZ LE DEPLOIEMENT.\n"
+        "\n"
+        "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n".format(active_jobs)
+    )
 
-        if active_jobs == 0:
-            print("No active smuggler jobs, safe to proceed with shutdown")
-            return
-
-        elapsed = int(time.time() - start_time)
-        if elapsed > 600:
-            raise Exception(
-                "\n"
-                "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
-                "\n"
-                "{} job(s) smuggler toujours actif(s) apres 10 minutes d'attente.\n"
-                "\n"
-                "=> RELANCEZ LE DEPLOIEMENT.\n"
-                "\n"
-                "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n".format(active_jobs)
-            )
-
-        print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
-        time.sleep(SHUTDOWN_CHECK_INTERVAL)
+        # print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
+        # time.sleep(SHUTDOWN_CHECK_INTERVAL)
 
 
 def ensure_environment_is_shut_down(environment):

--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -4,8 +4,9 @@ from . import constant as constant
 from . import manage_ecs as ecs_manager
 
 
-SHUTDOWN_CHECK_INTERVAL = 15  # seconds between polls
-SHUTDOWN_TIMEOUT = 900  # 15 minutes max, same as Lambda timeout budget
+SHUTDOWN_CHECK_INTERVAL = 15  # secondes entre chaque verification
+SHUTDOWN_TIMEOUT = 900  # 15 minutes max, correspond au timeout max de la Lambda
+SMUGGLER_JOBS_TIMEOUT = 600  # 10 minutes max, laisse assez de temps pour le shutdown + health check dans le timeout Lambda
 
 
 def _wait_for_active_jobs_to_complete(environment):
@@ -20,7 +21,7 @@ def _wait_for_active_jobs_to_complete(environment):
             return
 
         elapsed = int(time.time() - start_time)
-        if elapsed > 600:
+        if elapsed > SMUGGLER_JOBS_TIMEOUT:
             raise Exception(
                 "\n\n"
                 "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
@@ -32,7 +33,7 @@ def _wait_for_active_jobs_to_complete(environment):
                 "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n\n".format(active_jobs)
             )
 
-        print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
+        print("Waiting for smuggler jobs to complete: {} active ({}s / {}s)".format(active_jobs, elapsed, SMUGGLER_JOBS_TIMEOUT))
         time.sleep(SHUTDOWN_CHECK_INTERVAL)
 
 
@@ -57,24 +58,24 @@ def ensure_environment_is_shut_down(environment):
 
         if running_task_count == 0:
             elapsed = int(time.time() - start_time)
-            print("Pre-prod environment fully shut down in {}s, 0 tasks running".format(elapsed))
+            print("{} environment fully shut down in {}s, 0 tasks running".format(environment.color.upper(), elapsed))
             return
 
         elapsed = int(time.time() - start_time)
-        print("Waiting for pre-prod shutdown: {} task(s) still running ({}s / {}s) - services: {}".format(
-            running_task_count, elapsed, SHUTDOWN_TIMEOUT, ', '.join(services_with_tasks)))
+        print("Waiting for {} shutdown: {} task(s) still running ({}s / {}s) - services: {}".format(
+            environment.color.upper(), running_task_count, elapsed, SHUTDOWN_TIMEOUT, ', '.join(services_with_tasks)))
         time.sleep(SHUTDOWN_CHECK_INTERVAL)
 
     raise Exception(
-        "\n"
+        "\n\n"
         "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
         "\n"
-        "Le pre-prod a encore {} task(s) running apres {} secondes d'attente.\n"
+        "L'environnement a encore {} task(s) running apres {} secondes d'attente.\n"
         "Services concernes : {}\n"
         "\n"
         "=> RELANCEZ LE DEPLOIEMENT. Si le probleme persiste, verifiez l'etat des services dans la console ECS.\n"
         "\n"
-        "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n".format(
+        "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n\n".format(
             running_task_count, SHUTDOWN_TIMEOUT, ', '.join(services_with_tasks))
     )
 

--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -21,7 +21,16 @@ def _wait_for_active_jobs_to_complete(environment):
 
         elapsed = int(time.time() - start_time)
         if elapsed > 600:
-            raise Exception("Smuggler jobs still active after 600s. Active: {}. Aborting deployment".format(active_jobs))
+            raise Exception(
+                "\n"
+                "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
+                "\n"
+                "{} job(s) smuggler toujours actif(s) apres 10 minutes d'attente.\n"
+                "\n"
+                "=> RELANCEZ LE DEPLOIEMENT.\n"
+                "\n"
+                "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n".format(active_jobs)
+            )
 
         print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
         time.sleep(SHUTDOWN_CHECK_INTERVAL)
@@ -56,7 +65,18 @@ def ensure_environment_is_shut_down(environment):
             running_task_count, elapsed, SHUTDOWN_TIMEOUT, ', '.join(services_with_tasks)))
         time.sleep(SHUTDOWN_CHECK_INTERVAL)
 
-    raise Exception("Pre-prod environment still has running tasks after {}s, aborting deployment".format(SHUTDOWN_TIMEOUT))
+    raise Exception(
+        "\n"
+        "/!\\ /!\\ /!\\ ECHEC DU SHUTDOWN /!\\ /!\\ /!\\\n"
+        "\n"
+        "Le pre-prod a encore {} task(s) running apres {} secondes d'attente.\n"
+        "Services concernes : {}\n"
+        "\n"
+        "=> RELANCEZ LE DEPLOIEMENT. Si le probleme persiste, verifiez l'etat des services dans la console ECS.\n"
+        "\n"
+        "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n".format(
+            running_task_count, SHUTDOWN_TIMEOUT, ', '.join(services_with_tasks))
+    )
 
 
 # Démarre tous les services d'un environement et attend qu'il soit entièrement up

--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -59,27 +59,15 @@ def ensure_environment_is_shut_down(environment):
     raise Exception("Pre-prod environment still has running tasks after {}s, aborting deployment".format(SHUTDOWN_TIMEOUT))
 
 
-def _build_service_arn_to_digest(environment, repo_name_to_digest):
-    """Build a mapping of service ARN to expected image digest using the repo→service mapping."""
-    repo_service_map = ecs_manager.get_map_of_repo_name_service(environment.color, environment.cluster_name)
-    service_arn_to_digest = {}
-    for repo_name, digest in repo_name_to_digest.items():
-        if repo_name in repo_service_map:
-            service_arn_to_digest[repo_service_map[repo_name].service_arn] = digest
-    return service_arn_to_digest
-
-
 # Démarre tous les services d'un environement et attend qu'il soit entièrement up
-def start_environment_and_wait_for_health(environment, repo_name_to_digest=None):
-    if repo_name_to_digest:
-        service_arn_to_digest = _build_service_arn_to_digest(environment, repo_name_to_digest)
-        print("Digest verification enabled for {} services".format(len(service_arn_to_digest)))
-        environment.set_expected_image_digests(service_arn_to_digest)
-    else:
-        print("Digest verification disabled (no digest mapping provided)")
+def start_environment_and_wait_for_health(environment, verify_rollout=False):
+    if verify_rollout:
+        print("Rollout verification enabled for all {} services".format(len(environment.ecs_services)))
+        environment.enable_rollout_verification()
     print("Starting all {} services in {} environment".format(len(environment.ecs_services), environment.color))
     environment.start_up_services()
-    print("Waiting for all services to be healthy with correct image digest...")
+    print("Waiting for all services to be healthy{}...".format(
+        " and rollout complete" if verify_rollout else ""))
     environment.wait_for_services_health()
 
 
@@ -93,19 +81,10 @@ def do_balancing(deployment_manager, from_environment, to_environment):
     )
 
 
-def deploy_services_of_repositories_name(environment, repositories_name, repo_name_to_digest=None):
+def deploy_services_of_repositories_name(environment, repositories_name, verify_rollout=False):
     print("Deploy services for repositories: {}".format(repositories_name))
 
     repo_name_service_map = ecs_manager.get_map_of_repo_name_service(environment.color, environment.cluster_name)
-
-    # Set expected digests on the environment's own services (not the throwaway instances from the map)
-    if repo_name_to_digest:
-        service_arn_to_digest = {}
-        for repo_name, digest in repo_name_to_digest.items():
-            if repo_name in repo_name_service_map:
-                service_arn_to_digest[repo_name_service_map[repo_name].service_arn] = digest
-        print("Digest verification enabled for {} services".format(len(service_arn_to_digest)))
-        environment.set_expected_image_digests(service_arn_to_digest)
 
     # Collect environment services that match the repositories to deploy
     services_to_start = []
@@ -121,6 +100,10 @@ def deploy_services_of_repositories_name(environment, repositories_name, repo_na
     print("Matched {} services to redeploy out of {} repositories".format(
         len(services_to_start), len(repositories_name)))
 
+    if verify_rollout and services_to_start:
+        print("Rollout verification enabled for {} services".format(len(services_to_start)))
+        environment.enable_rollout_verification(services=services_to_start)
+
     if services_to_start:
         for service in services_to_start:
             print("Start service {}".format(service.resource_id))
@@ -128,7 +111,8 @@ def deploy_services_of_repositories_name(environment, repositories_name, repo_na
 
         # Wait only for the deployed services to be healthy (not all services in the environment)
         time.sleep(10)
-        print("Waiting for {} redeployed services to be healthy with correct image digest...".format(len(services_to_start)))
+        print("Waiting for {} redeployed services to be healthy{}...".format(
+            len(services_to_start), " and rollout complete" if verify_rollout else ""))
         environment.wait_for_services_health(services=services_to_start)
     else:
         print("No matching services found to redeploy")

--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -1,11 +1,85 @@
 import time
 
+from . import constant as constant
 from . import manage_ecs as ecs_manager
 
 
+SHUTDOWN_CHECK_INTERVAL = 15  # seconds between polls
+SHUTDOWN_TIMEOUT = 900  # 15 minutes max, same as Lambda timeout budget
+
+
+def _wait_for_active_jobs_to_complete(environment):
+    """Wait for all smuggler jobs to complete before shutting down, max 10 minutes."""
+    start_time = time.time()
+    while True:
+        metrics = environment.get_active_and_pending_smuggler_jobs()
+        active_jobs = metrics.get('active_jobs', 0)
+
+        if active_jobs == 0:
+            print("No active smuggler jobs, safe to proceed with shutdown")
+            return
+
+        elapsed = int(time.time() - start_time)
+        if elapsed > 600:
+            raise Exception("Smuggler jobs still active after 600s. Active: {}. Aborting deployment".format(active_jobs))
+
+        print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
+        time.sleep(SHUTDOWN_CHECK_INTERVAL)
+
+
+def ensure_environment_is_shut_down(environment):
+    """Ensure all services in the environment have 0 running tasks before proceeding.
+    This prevents old version tasks from coexisting with new ones after image tags are updated."""
+    _wait_for_active_jobs_to_complete(environment)
+
+    print("Sending shutdown to all {} services in {} environment".format(
+        len(environment.ecs_services), environment.color))
+    environment.shutdown_services()
+
+    start_time = time.time()
+    while (time.time() - start_time) < SHUTDOWN_TIMEOUT:
+        running_task_count = 0
+        services_with_tasks = []
+        for svc in environment.ecs_services:
+            tasks = svc.get_running_task_arns()
+            if tasks:
+                running_task_count += len(tasks)
+                services_with_tasks.append('{} ({})'.format(svc.service_arn, len(tasks)))
+
+        if running_task_count == 0:
+            elapsed = int(time.time() - start_time)
+            print("Pre-prod environment fully shut down in {}s, 0 tasks running".format(elapsed))
+            return
+
+        elapsed = int(time.time() - start_time)
+        print("Waiting for pre-prod shutdown: {} task(s) still running ({}s / {}s) - services: {}".format(
+            running_task_count, elapsed, SHUTDOWN_TIMEOUT, ', '.join(services_with_tasks)))
+        time.sleep(SHUTDOWN_CHECK_INTERVAL)
+
+    raise Exception("Pre-prod environment still has running tasks after {}s, aborting deployment".format(SHUTDOWN_TIMEOUT))
+
+
+def _build_service_arn_to_digest(environment, repo_name_to_digest):
+    """Build a mapping of service ARN to expected image digest using the repo→service mapping."""
+    repo_service_map = ecs_manager.get_map_of_repo_name_service(environment.color, environment.cluster_name)
+    service_arn_to_digest = {}
+    for repo_name, digest in repo_name_to_digest.items():
+        if repo_name in repo_service_map:
+            service_arn_to_digest[repo_service_map[repo_name].service_arn] = digest
+    return service_arn_to_digest
+
+
 # Démarre tous les services d'un environement et attend qu'il soit entièrement up
-def start_environment_and_wait_for_health(environment):
+def start_environment_and_wait_for_health(environment, repo_name_to_digest=None):
+    if repo_name_to_digest:
+        service_arn_to_digest = _build_service_arn_to_digest(environment, repo_name_to_digest)
+        print("Digest verification enabled for {} services".format(len(service_arn_to_digest)))
+        environment.set_expected_image_digests(service_arn_to_digest)
+    else:
+        print("Digest verification disabled (no digest mapping provided)")
+    print("Starting all {} services in {} environment".format(len(environment.ecs_services), environment.color))
     environment.start_up_services()
+    print("Waiting for all services to be healthy with correct image digest...")
     environment.wait_for_services_health()
 
 
@@ -19,24 +93,42 @@ def do_balancing(deployment_manager, from_environment, to_environment):
     )
 
 
-def deploy_services_of_repositories_name(environment, repositories_name):
-    print("Deploy services for repositories {}".format(repositories_name))
-
-    services_to_start = []
+def deploy_services_of_repositories_name(environment, repositories_name, repo_name_to_digest=None):
+    print("Deploy services for repositories: {}".format(repositories_name))
 
     repo_name_service_map = ecs_manager.get_map_of_repo_name_service(environment.color, environment.cluster_name)
 
-    # récupère les services à démarrer issus des repositories donnés
+    # Set expected digests on the environment's own services (not the throwaway instances from the map)
+    if repo_name_to_digest:
+        service_arn_to_digest = {}
+        for repo_name, digest in repo_name_to_digest.items():
+            if repo_name in repo_name_service_map:
+                service_arn_to_digest[repo_name_service_map[repo_name].service_arn] = digest
+        print("Digest verification enabled for {} services".format(len(service_arn_to_digest)))
+        environment.set_expected_image_digests(service_arn_to_digest)
+
+    # Collect environment services that match the repositories to deploy
+    services_to_start = []
     for repo_name in repositories_name:
         if repo_name in repo_name_service_map:
-            service = repo_name_service_map[repo_name]
-            services_to_start.append(service)
+            target_arn = repo_name_service_map[repo_name].service_arn
+            # Find the matching service in the environment's own list
+            for svc in environment.ecs_services:
+                if svc.service_arn == target_arn:
+                    services_to_start.append(svc)
+                    break
+
+    print("Matched {} services to redeploy out of {} repositories".format(
+        len(services_to_start), len(repositories_name)))
 
     if services_to_start:
         for service in services_to_start:
             print("Start service {}".format(service.resource_id))
             service.start()
 
-        # Wait for all service receive startup
+        # Wait only for the deployed services to be healthy (not all services in the environment)
         time.sleep(10)
-        environment.all_services_have_at_least_one_healthy_instance()
+        print("Waiting for {} redeployed services to be healthy with correct image digest...".format(len(services_to_start)))
+        environment.wait_for_services_health(services=services_to_start)
+    else:
+        print("No matching services found to redeploy")

--- a/lcdp_deployment_manager/deployment_executor.py
+++ b/lcdp_deployment_manager/deployment_executor.py
@@ -10,30 +10,30 @@ SHUTDOWN_TIMEOUT = 900  # 15 minutes max, same as Lambda timeout budget
 
 def _wait_for_active_jobs_to_complete(environment):
     """Wait for all smuggler jobs to complete before shutting down, max 10 minutes."""
-    # start_time = time.time()
-    # while True:
-    metrics = environment.get_active_and_pending_smuggler_jobs()
-    active_jobs = metrics.get('active_jobs', 0)
-    #
-    #     if active_jobs == 0:
-    #         print("No active smuggler jobs, safe to proceed with shutdown")
-    #         return
-    #
-    #     elapsed = int(time.time() - start_time)
-    #     if elapsed > 600:
-    raise Exception(
-        "\n"
-        "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
-        "\n"
-        "{} job(s) smuggler toujours actif(s) apres 10 minutes d'attente.\n"
-        "\n"
-        "=> RELANCEZ LE DEPLOIEMENT.\n"
-        "\n"
-        "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n".format(active_jobs)
-    )
+    start_time = time.time()
+    while True:
+        metrics = environment.get_active_and_pending_smuggler_jobs()
+        active_jobs = metrics.get('active_jobs', 0)
 
-        # print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
-        # time.sleep(SHUTDOWN_CHECK_INTERVAL)
+        if active_jobs == 0:
+            print("No active smuggler jobs, safe to proceed with shutdown")
+            return
+
+        elapsed = int(time.time() - start_time)
+        if elapsed > 600:
+            raise Exception(
+                "\n\n"
+                "/!\\ /!\\ /!\\ ECHEC DU DEPLOIEMENT /!\\ /!\\ /!\\\n"
+                "\n"
+                "{} job(s) smuggler toujours actif(s) apres 10 minutes d'attente.\n"
+                "\n"
+                "=> RELANCEZ LE DEPLOIEMENT.\n"
+                "\n"
+                "/!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\ /!\\\n\n".format(active_jobs)
+            )
+
+        print("Waiting for smuggler jobs to complete: {} active ({}s / 600s)".format(active_jobs, elapsed))
+        time.sleep(SHUTDOWN_CHECK_INTERVAL)
 
 
 def ensure_environment_is_shut_down(environment):

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -297,9 +297,10 @@ class EcsService:
             desired_count = constant.DEFAULT_DESIRED_COUNT
         print('Start service {} with {} instances'.format(self.service_arn, desired_count))
         # First update the ECS SHA1 image to pull
-        response = self.ecs_client.update_service(
+        self.ecs_client.update_service(
             cluster=self.cluster_name,
             service=self.service_arn,
+            desiredCount=desired_count,
             forceNewDeployment=True
         )
 
@@ -313,13 +314,6 @@ class EcsService:
                 'Delay': 10,  # vérifie toutes les 10s
                 'MaxAttempts': 30  # timeout après 5 minutes
             }
-        )
-
-        # Deployment is ready, increase the number of service
-        self.ecs_client.update_service(
-            cluster=self.cluster_name,
-            service=self.service_arn,
-            desiredCount=desired_count,
         )
 
         response = self.__set_register_scalable_target(desired_count)

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -16,7 +16,7 @@ class DeploymentManager:
     default_target_group = None
     rules = []
     repositories = []
-    prod_color = None
+    active_color = None
     blue_environment = {}
     green_environment = {}
 
@@ -24,7 +24,7 @@ class DeploymentManager:
     elbv2_client = None
 
     def __init__(self, elbv2_client, alb, http_listener, rules, repositories,
-                 prod_color, current_target_group_type,
+                 active_color, current_target_group_type,
                  blue_environment,
                  green_environment):
         self.elbv2_client = elbv2_client
@@ -32,7 +32,7 @@ class DeploymentManager:
         self.http_listener = http_listener
         self.rules = rules
         self.repositories = repositories
-        self.prod_color = prod_color
+        self.active_color = active_color
         self.current_target_group_type = current_target_group_type
         self.blue_environment = blue_environment
         self.green_environment = green_environment
@@ -54,19 +54,21 @@ class DeploymentManager:
         else:
             return None
 
-    def get_production_environment(self):
-        if self.prod_color == constant.BLUE:
+    def get_active_environment(self):
+        """Retourne l'environnement qui recoit actuellement le trafic."""
+        if self.active_color == constant.BLUE:
             return self.blue_environment
-        elif self.prod_color == constant.GREEN:
+        elif self.active_color == constant.GREEN:
             return self.green_environment
-        raise Exception('Unable to get prod environment...')
+        raise Exception('Unable to get active environment...')
 
-    def get_pre_production_environment(self):
-        if self.prod_color == constant.GREEN:
+    def get_inactive_environment(self):
+        """Retourne l'environnement qui ne recoit pas de trafic."""
+        if self.active_color == constant.GREEN:
             return self.blue_environment
-        elif self.prod_color == constant.BLUE:
+        elif self.active_color == constant.BLUE:
             return self.green_environment
-        raise Exception('Unable to get pre prod environment...')
+        raise Exception('Unable to get inactive environment...')
 
     def create_rule(self, conditions, actions, priority, tags):
         self.elbv2_client.create_rule(
@@ -137,18 +139,18 @@ class DeploymentManager:
             r.add_tag(tag)
 
     def set_color_to_list_repositories_name(self, repositories_name):
-        print('Add color {} to mismatched repositories: {}'.format(self.prod_color, repositories_name))
+        print('Add color {} to mismatched repositories: {}'.format(self.active_color, repositories_name))
 
         for r in self.repositories:
             if r.name in repositories_name:
-                r.add_tag(self.prod_color.upper())
+                r.add_tag(self.active_color.upper())
 
     # Cherche les repositories qui ont un tag mais pour lesquels la couleur active n'est pas appliquée et applique la
     def find_mismatched_repositories_name_between_tag_and_active_color(self, tag):
         return ecr_manager.find_mismatched_repositories_between_tag_and_color(
             ecr_manager.get_service_repositories_name(),
             tag,
-            self.prod_color)
+            self.active_color)
 
     def get_lowest_available_priority_alb_rule(self):
         used_priorities = set()

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -136,10 +136,6 @@ class DeploymentManager:
         for r in self.repositories:
             r.add_tag(tag)
 
-    def get_expected_image_digests_by_repo(self):
-        """Returns a dict mapping repository name to expected imageDigest."""
-        return {r.name: r.image['imageDigest'] for r in self.repositories if r.image}
-
     def set_color_to_list_repositories_name(self, repositories_name):
         print('Add color {} to mismatched repositories: {}'.format(self.prod_color, repositories_name))
 
@@ -192,15 +188,15 @@ class Environment:
         self.ecs_services = ecs_services
         self.target_group_arn = target_group_arn
 
-    def set_expected_image_digests(self, service_arn_to_digest):
-        """Assign the expected image digest to each service.
+    def enable_rollout_verification(self, services=None):
+        """Enable rollout verification on services to ensure no old tasks coexist with new ones.
         Args:
-            service_arn_to_digest: dict mapping service ARN to expected imageDigest
+            services: list of EcsService to enable on (defaults to all services)
         """
-        for svc in self.ecs_services:
-            if svc.service_arn in service_arn_to_digest:
-                svc.expected_image_digest = service_arn_to_digest[svc.service_arn]
-                print('Set expected image digest for {}: {}'.format(svc.service_arn, svc.expected_image_digest))
+        target_services = services if services is not None else self.ecs_services
+        for svc in target_services:
+            svc.verify_rollout_complete = True
+            print('Rollout verification enabled for {}'.format(svc.service_arn))
 
     # Démarre tous les services
     def start_up_services(self, desired_count=None):
@@ -261,17 +257,16 @@ class EcsService:
     application_autoscaling_client = None
     max_capacity = None
     resource_id = None
-    expected_image_digest = None
+    verify_rollout_complete = False
 
     def __init__(self, ecs_client, application_autoscaling_client, cluster_name, service_arn, max_capacity,
-                 resource_id, expected_image_digest=None):
+                 resource_id):
         self.ecs_client = ecs_client
         self.cluster_name = cluster_name
         self.service_arn = service_arn
         self.application_autoscaling_client = application_autoscaling_client
         self.max_capacity = max_capacity
         self.resource_id = resource_id
-        self.expected_image_digest = expected_image_digest
 
     def get_running_task_arns(self):
         tasks = self.ecs_client.list_tasks(
@@ -345,13 +340,10 @@ class EcsService:
         nb_healthy_task = len([t for t in running_tasks if t['healthStatus'] == 'HEALTHY'])
         is_healthy = nb_healthy_task >= min_healthy_count
 
-        # If we have an expected image digest, verify ALL running tasks use the new image.
-        # This prevents old version tasks from coexisting with new ones during rolling updates.
-        if is_healthy and self.expected_image_digest:
-            old_tasks = self.__get_tasks_with_wrong_digest(running_tasks)
-            if old_tasks:
-                print('{} has {} healthy task(s) but {} task(s) still running with old image digest, waiting for rollout to complete'
-                      .format(self.service_arn, nb_healthy_task, len(old_tasks)))
+        # Verify the rolling update is fully complete (only PRIMARY deployment remains).
+        # This prevents old version tasks from coexisting with new ones.
+        if is_healthy and self.verify_rollout_complete:
+            if not self.__has_completed_rollout():
                 return False
 
         if is_healthy:
@@ -362,16 +354,26 @@ class EcsService:
                   .format(self.service_arn, nb_healthy_task, min_healthy_count))
         return is_healthy
 
-    def __get_tasks_with_wrong_digest(self, running_tasks):
-        """Returns tasks whose container image digest does not match the expected digest."""
-        old_tasks = []
-        for task in running_tasks:
-            for container in task.get('containers', []):
-                image_digest = container.get('imageDigest', '')
-                if image_digest and image_digest != self.expected_image_digest:
-                    old_tasks.append(task['taskArn'])
-                    break
-        return old_tasks
+    def __has_completed_rollout(self):
+        """Check that no old deployment has running tasks, meaning the rolling update is done.
+        ECS may keep old deployment records briefly after tasks stop, so we check runningCount
+        rather than deployment count."""
+        response = self.ecs_client.describe_services(
+            cluster=self.cluster_name,
+            services=[self.service_arn]
+        )
+        service = response['services'][0]
+        deployments = service.get('deployments', [])
+        old_deployments_with_tasks = [d for d in deployments
+                                      if d['status'] != 'PRIMARY' and d['runningCount'] > 0]
+        if not old_deployments_with_tasks:
+            print('{} rollout complete: no old deployment has running tasks'.format(self.service_arn))
+            return True
+        deployment_info = ['{} (status={}, running={}, desired={})'.format(
+            d['id'], d['status'], d['runningCount'], d['desiredCount']) for d in deployments]
+        print('{} rollout in progress: {} old deployment(s) still have running tasks - {}'.format(
+            self.service_arn, len(old_deployments_with_tasks), ', '.join(deployment_info)))
+        return False
 
     def __str__(self):
         return self.service_arn

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -203,15 +203,15 @@ class Environment:
 
     # Démarre tous les services en parallèle
     def start_up_services(self, desired_count=None):
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=len(self.ecs_services)) as executor:
             list(executor.map(lambda s: s.start(desired_count), self.ecs_services))
         # Wait for all service receive startup
         time.sleep(10)
 
     # Eteint tous les services
     def shutdown_services(self):
-        for s in self.ecs_services:
-            s.shutdown()
+        with ThreadPoolExecutor(max_workers=len(self.ecs_services)) as executor:
+            list(executor.map(lambda s: s.shutdown(), self.ecs_services))
         # Wait for all service receive shutdown
         time.sleep(10)
 
@@ -304,7 +304,7 @@ class EcsService:
         )
 
         # Then, wait for the deployment to be done
-        print('Waiting for deployment to stabilize...')
+        print('Waiting for deployment of service {} to stabilize...'.format(self.service_arn))
         waiter = self.ecs_client.get_waiter('services_stable')
         waiter.wait(
             cluster=self.cluster_name,

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -297,10 +297,9 @@ class EcsService:
             desired_count = constant.DEFAULT_DESIRED_COUNT
         print('Start service {} with {} instances'.format(self.service_arn, desired_count))
         # First update the ECS SHA1 image to pull
-        self.ecs_client.update_service(
+        response = self.ecs_client.update_service(
             cluster=self.cluster_name,
             service=self.service_arn,
-            desiredCount=desired_count,
             forceNewDeployment=True
         )
 
@@ -314,6 +313,13 @@ class EcsService:
                 'Delay': 10,  # vérifie toutes les 10s
                 'MaxAttempts': 30  # timeout après 5 minutes
             }
+        )
+
+        # Deployment is ready, increase the number of service
+        self.ecs_client.update_service(
+            cluster=self.cluster_name,
+            service=self.service_arn,
+            desiredCount=desired_count,
         )
 
         response = self.__set_register_scalable_target(desired_count)

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -1,4 +1,5 @@
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from . import common as common
 from . import constant as constant
@@ -200,10 +201,17 @@ class Environment:
             svc.verify_rollout_complete = True
             print('Rollout verification enabled for {}'.format(svc.service_arn))
 
-    # Démarre tous les services
+    # Démarre tous les services en parallèle
     def start_up_services(self, desired_count=None):
-        for s in self.ecs_services:
-            s.start(desired_count)
+        with ThreadPoolExecutor(max_workers=len(self.ecs_services)) as executor:
+            futures = {executor.submit(s.start, desired_count): s for s in self.ecs_services}
+            for future in as_completed(futures):
+                service = futures[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    print("Error starting service {}: {}".format(service.service_arn, e))
+                    raise
         # Wait for all service receive startup
         time.sleep(10)
 

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -1,5 +1,5 @@
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 
 from . import common as common
 from . import constant as constant
@@ -203,15 +203,8 @@ class Environment:
 
     # Démarre tous les services en parallèle
     def start_up_services(self, desired_count=None):
-        with ThreadPoolExecutor(max_workers=len(self.ecs_services)) as executor:
-            futures = {executor.submit(s.start, desired_count): s for s in self.ecs_services}
-            for future in as_completed(futures):
-                service = futures[future]
-                try:
-                    future.result()
-                except Exception as e:
-                    print("Error starting service {}: {}".format(service.service_arn, e))
-                    raise
+        with ThreadPoolExecutor() as executor:
+            list(executor.map(lambda s: s.start(desired_count), self.ecs_services))
         # Wait for all service receive startup
         time.sleep(10)
 

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -136,6 +136,10 @@ class DeploymentManager:
         for r in self.repositories:
             r.add_tag(tag)
 
+    def get_expected_image_digests_by_repo(self):
+        """Returns a dict mapping repository name to expected imageDigest."""
+        return {r.name: r.image['imageDigest'] for r in self.repositories if r.image}
+
     def set_color_to_list_repositories_name(self, repositories_name):
         print('Add color {} to mismatched repositories: {}'.format(self.prod_color, repositories_name))
 
@@ -188,6 +192,16 @@ class Environment:
         self.ecs_services = ecs_services
         self.target_group_arn = target_group_arn
 
+    def set_expected_image_digests(self, service_arn_to_digest):
+        """Assign the expected image digest to each service.
+        Args:
+            service_arn_to_digest: dict mapping service ARN to expected imageDigest
+        """
+        for svc in self.ecs_services:
+            if svc.service_arn in service_arn_to_digest:
+                svc.expected_image_digest = service_arn_to_digest[svc.service_arn]
+                print('Set expected image digest for {}: {}'.format(svc.service_arn, svc.expected_image_digest))
+
     # Démarre tous les services
     def start_up_services(self, desired_count=None):
         for s in self.ecs_services:
@@ -212,20 +226,21 @@ class Environment:
     def all_services_have_at_least_one_healthy_instance(self):
         return all(s.has_at_least_one_healthy_instance() for s in self.ecs_services)
 
-    # Attend que tous les services soit healthy
-    def wait_for_services_health(self):
+    # Attend que tous les services (ou un sous-ensemble) soient healthy
+    def wait_for_services_health(self, services=None):
+        target_services = services if services is not None else self.ecs_services
         retry = 1
         print("Waiting {} seconds before first try".format(constant.HEALTHCHECK_SLEEPING_TIME))
         time.sleep(constant.HEALTHCHECK_SLEEPING_TIME)
-        while not self.all_services_have_at_least_one_healthy_instance() and constant.HEALTHCHECK_RETRY_LIMIT >= retry:
+        while not all(s.has_at_least_one_healthy_instance() for s in target_services) and constant.HEALTHCHECK_RETRY_LIMIT >= retry:
             print("Retry number {} all services hasnt healthy sleeping {} seconds before retry"
                   .format(retry, constant.HEALTHCHECK_SLEEPING_TIME))
             retry = retry + 1
             time.sleep(constant.HEALTHCHECK_SLEEPING_TIME)
         if constant.HEALTHCHECK_RETRY_LIMIT < retry:
             print("Tried {} but retry limit has been reach before all services been healthy".format(retry))
-            # Raise exception
-            unhealthy_sve = ",".join(list(map(lambda a: a.service_arn, self.get_unhealthy_services())))
+            unhealthy = [s for s in target_services if not s.has_at_least_one_healthy_instance()]
+            unhealthy_sve = ",".join(list(map(lambda a: a.service_arn, unhealthy)))
             raise Exception("Unable to deploy, services still unhealthy. Unhealthy Services : {}".format(unhealthy_sve))
         else:
             print("Tried {} and all service are now healthy".format(retry))
@@ -246,17 +261,19 @@ class EcsService:
     application_autoscaling_client = None
     max_capacity = None
     resource_id = None
+    expected_image_digest = None
 
     def __init__(self, ecs_client, application_autoscaling_client, cluster_name, service_arn, max_capacity,
-                 resource_id):
+                 resource_id, expected_image_digest=None):
         self.ecs_client = ecs_client
         self.cluster_name = cluster_name
         self.service_arn = service_arn
         self.application_autoscaling_client = application_autoscaling_client
         self.max_capacity = max_capacity
         self.resource_id = resource_id
+        self.expected_image_digest = expected_image_digest
 
-    def __get_task(self):
+    def get_running_task_arns(self):
         tasks = self.ecs_client.list_tasks(
             cluster=self.cluster_name,
             serviceName=self.service_arn,
@@ -317,15 +334,26 @@ class EcsService:
         return self.__check_health_with_threshold(constant.DEFAULT_DESIRED_COUNT)
 
     def __check_health_with_threshold(self, min_healthy_count):
-        tasks = self.__get_task()
+        tasks = self.get_running_task_arns()
         if not tasks:
             return False
         detailed_task = self.ecs_client.describe_tasks(
             cluster=self.cluster_name,
             tasks=tasks
         )
-        nb_healthy_task = len(list(filter(lambda x: x['healthStatus'] == 'HEALTHY', detailed_task['tasks'])))
+        running_tasks = [t for t in detailed_task['tasks'] if t['lastStatus'] == 'RUNNING']
+        nb_healthy_task = len([t for t in running_tasks if t['healthStatus'] == 'HEALTHY'])
         is_healthy = nb_healthy_task >= min_healthy_count
+
+        # If we have an expected image digest, verify ALL running tasks use the new image.
+        # This prevents old version tasks from coexisting with new ones during rolling updates.
+        if is_healthy and self.expected_image_digest:
+            old_tasks = self.__get_tasks_with_wrong_digest(running_tasks)
+            if old_tasks:
+                print('{} has {} healthy task(s) but {} task(s) still running with old image digest, waiting for rollout to complete'
+                      .format(self.service_arn, nb_healthy_task, len(old_tasks)))
+                return False
+
         if is_healthy:
             print('{} has reached the health threshold with {} healthy task(s) (required: {})'
                   .format(self.service_arn, nb_healthy_task, min_healthy_count))
@@ -333,6 +361,17 @@ class EcsService:
             print('{} has not reached the health threshold: {} healthy task(s) found, {} required'
                   .format(self.service_arn, nb_healthy_task, min_healthy_count))
         return is_healthy
+
+    def __get_tasks_with_wrong_digest(self, running_tasks):
+        """Returns tasks whose container image digest does not match the expected digest."""
+        old_tasks = []
+        for task in running_tasks:
+            for container in task.get('containers', []):
+                image_digest = container.get('imageDigest', '')
+                if image_digest and image_digest != self.expected_image_digest:
+                    old_tasks.append(task['taskArn'])
+                    break
+        return old_tasks
 
     def __str__(self):
         return self.service_arn

--- a/lcdp_deployment_manager/deployment_manager.py
+++ b/lcdp_deployment_manager/deployment_manager.py
@@ -295,12 +295,32 @@ class EcsService:
         if not desired_count:
             desired_count = constant.DEFAULT_DESIRED_COUNT
         print('Start service {} with {} instances'.format(self.service_arn, desired_count))
+        # First update the ECS SHA1 image to pull
+        response = self.ecs_client.update_service(
+            cluster=self.cluster_name,
+            service=self.service_arn,
+            forceNewDeployment=True
+        )
+
+        # Then, wait for the deployment to be done
+        print('Waiting for deployment to stabilize...')
+        waiter = self.ecs_client.get_waiter('services_stable')
+        waiter.wait(
+            cluster=self.cluster_name,
+            services=[self.service_arn],
+            WaiterConfig={
+                'Delay': 10,  # vérifie toutes les 10s
+                'MaxAttempts': 30  # timeout après 5 minutes
+            }
+        )
+
+        # Deployment is ready, increase the number of service
         self.ecs_client.update_service(
             cluster=self.cluster_name,
             service=self.service_arn,
             desiredCount=desired_count,
-            forceNewDeployment=True
         )
+
         response = self.__set_register_scalable_target(desired_count)
         print("Started service: '{}', Updated Capacities => MaxCapacity: {} / MinCapacity: {}, response: {}"
               .format(self.service_arn, self.max_capacity, desired_count, response))

--- a/lcdp_deployment_manager/deployment_manager_factory.py
+++ b/lcdp_deployment_manager/deployment_manager_factory.py
@@ -17,8 +17,8 @@ def build_deployment_manager(alb_name, cluster_name, img_deploy_tag, ssl_enabled
     alb = alb_manager.get_alb_from_aws(alb_name)
     listener = alb_manager.get_current_listener(alb['LoadBalancerArn'], ssl_enabled)
     rules = alb_manager.get_uncolored_rules(listener)
-    prod_color = alb_manager.get_production_color(listener)
-    current_target_group_type = alb_manager.get_production_type(listener)
+    active_color = alb_manager.get_active_color(listener)
+    current_target_group_type = alb_manager.get_active_type(listener)
     repositories = list(
         map(lambda x: __build_repository(x, img_deploy_tag), ecr_manager.get_service_repositories_name()))
     green_environment = __build_environment(constant.GREEN, current_target_group_type,
@@ -31,7 +31,7 @@ def build_deployment_manager(alb_name, cluster_name, img_deploy_tag, ssl_enabled
         alb=alb,
         http_listener=listener,
         rules=[r for r in rules if r],
-        prod_color=prod_color,
+        active_color=active_color,
         current_target_group_type=current_target_group_type,
         repositories=[r for r in repositories if r],
         green_environment=green_environment,

--- a/lcdp_deployment_manager/manage_alb.py
+++ b/lcdp_deployment_manager/manage_alb.py
@@ -32,9 +32,9 @@ def get_current_listener(alb_arn, ssl_enabled):
     return __get_listener(alb_desc, ssl_enabled)
 
 
-def get_production_color(listener):
+def get_active_color(listener):
     """
-    Récupère la couleur actuellement en production
+    Recupere la couleur de l'environnement actif (celui qui recoit le trafic)
     :param listener:    listener actuel
     :type listener:     dict
     :return:            BLUE/GREEN
@@ -43,9 +43,9 @@ def get_production_color(listener):
     current_target_group_arn = __get_default_forward_target_group_arn_from_listener(listener)
     return __get_color_from_resource(current_target_group_arn)
 
-def get_production_type(listener):
+def get_active_type(listener):
     """
-    Récupère le type actuellement en production
+    Recupere le type de l'environnement actif
     :param listener:    listener actuel
     :type listener:     dict
     :return:            default/maintenance


### PR DESCRIPTION
## Summary

  - Ajout de `ensure_environment_is_shut_down` : attend la fin des jobs smuggler puis confirme qu'il y a 0 tasks running avant de rendre la main
  - Vérification de fin de rollout ECS dans le health check : tant qu'un ancien deploiement a des tasks running, le service n'est pas considéré comme healthy
  - `wait_for_services_health` accepte un sous-ensemble de services (utilisé par le hotfix pour ne vérifier que les services redéployés)
  - `get_running_task_arns` rendu public (anciennement `__get_task`)

  ## Contexte

  Lors de certains déploiements, des tasks avec l'ancien SHA coexistaient avec les nouvelles tasks. L'ancienne version pouvait appliquer des évolutions BDD incompatibles.

  Deux causes identifiées :
  1. La pre-prod n'était pas toujours éteinte avant la mise à jour des tags ECR
  2. Le health check ne vérifiait pas la fin du rolling update ECS — une ancienne task healthy suffisait à continuer le flow

  ## Test plan

  - [x] Déploiement standard en staging avec pre-prod déjà éteint → shutdown immédiat, rollout vérifié, bascule OK
  - [x] Déploiement avec pre-prod encore actif (simulation shutdown raté) → anciennes tasks détectées via rollout check, attente du drain, puis bascule
  - [x] Lambda hotfix testée sur un sous-ensemble de services
  - [x] Lambdas rollback et shutdown non impactées (aucun changement de signature cassant)